### PR TITLE
fix - remove check for embedding model when using azure open ai

### DIFF
--- a/chains/llm_azure_test.go
+++ b/chains/llm_azure_test.go
@@ -26,8 +26,6 @@ func TestLLMChainAzure(t *testing.T) {
 		openai.WithAPIType(openai.APITypeAzure),
 		// Azure deployment that uses desired model, the name depends on what we define in the Azure deployment section
 		openai.WithModel("model-name"),
-		// Azure deployment that uses embeddings model, the name depends on what we define in the Azure deployment section
-		openai.WithEmbeddingModel("embeddings-model-name"),
 	)
 	require.NoError(t, err)
 

--- a/llms/openai/llm.go
+++ b/llms/openai/llm.go
@@ -34,9 +34,6 @@ func newClient(opts ...Option) (*options, *openaiclient.Client, error) {
 	// set of options needed for Azure client
 	if openaiclient.IsAzure(openaiclient.APIType(options.apiType)) && options.apiVersion == "" {
 		options.apiVersion = DefaultAPIVersion
-		if options.embeddingModel == "" {
-			return options, nil, ErrMissingAzureEmbeddingModel
-		}
 	}
 
 	if len(options.token) == 0 {


### PR DESCRIPTION
Removes an options check that ensures an embedding model is configured when using Azure OpenAI llm type.

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [x] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
